### PR TITLE
Remove the Lambdas From Vpc.

### DIFF
--- a/aws-configuration/lambda/Connect.tf
+++ b/aws-configuration/lambda/Connect.tf
@@ -12,17 +12,7 @@ resource "aws_lambda_function" "connect_function" {
   memory_size      = 128
 
   layers           = [ data.aws_lambda_layer_version.lambda_secretsmanager_layer.arn ]
-  
-  vpc_config {
-    subnet_ids         = local.subnet_ids
-    security_group_ids = [data.aws_security_group.lambda_security.id]
-  }
 
-  #lifecycle {
-  #  ignore_changes = [
-  #    filename
-  #  ]
-  #}
 
   provider = aws.europe_london
 }
@@ -30,7 +20,7 @@ resource "aws_lambda_function" "connect_function" {
 resource "aws_lambda_function_event_invoke_config" "connect_function_config" {
   function_name                = aws_lambda_function.connect_function.function_name
   maximum_event_age_in_seconds = 60
-  maximum_retry_attempts       = 2
+  maximum_retry_attempts       = 1
 
   provider = aws.europe_london
 }

--- a/aws-configuration/lambda/Default.tf
+++ b/aws-configuration/lambda/Default.tf
@@ -12,17 +12,6 @@ resource "aws_lambda_function" "default_function" {
   memory_size      = 128
 
   layers           = [ data.aws_lambda_layer_version.lambda_secretsmanager_layer.arn ]
-  
-  vpc_config {
-    subnet_ids         = local.subnet_ids
-    security_group_ids = [data.aws_security_group.lambda_security.id]
-  }
-
-  #lifecycle {
-  #  ignore_changes = [
-  #    filename
-  #  ]
-  #}
 
   provider = aws.europe_london
 }
@@ -30,7 +19,7 @@ resource "aws_lambda_function" "default_function" {
 resource "aws_lambda_function_event_invoke_config" "default_function_config" {
   function_name                = aws_lambda_function.default_function.function_name
   maximum_event_age_in_seconds = 60
-  maximum_retry_attempts       = 2
+  maximum_retry_attempts       = 1
 
   provider = aws.europe_london
 }

--- a/aws-configuration/lambda/Disconnect.tf
+++ b/aws-configuration/lambda/Disconnect.tf
@@ -12,17 +12,6 @@ resource "aws_lambda_function" "disconnect_function" {
   memory_size      = 128
 
   layers           = [ data.aws_lambda_layer_version.lambda_secretsmanager_layer.arn ]
-  
-  vpc_config {
-    subnet_ids         = local.subnet_ids
-    security_group_ids = [data.aws_security_group.lambda_security.id]
-  }
-
-  #lifecycle {
-  #  ignore_changes = [
-  #    filename
-  #  ]
-  #}
 
   provider = aws.europe_london
 }
@@ -30,7 +19,7 @@ resource "aws_lambda_function" "disconnect_function" {
 resource "aws_lambda_function_event_invoke_config" "disconnect_function_config" {
   function_name                = aws_lambda_function.disconnect_function.function_name
   maximum_event_age_in_seconds = 60
-  maximum_retry_attempts       = 2
+  maximum_retry_attempts       = 1
 
   provider = aws.europe_london
 }

--- a/aws-configuration/lambda/_data.tf
+++ b/aws-configuration/lambda/_data.tf
@@ -1,19 +1,8 @@
-locals {
-  subnet_ids = ["subnet-0c13306ed1110d72b", "subnet-0924e5edbe03c3150", "subnet-04ae8c6987e2cc906"]
-}
-
 data "aws_iam_role" "lambda_iam_role" {
   name = "LambdaExecution"
 
   provider = aws.europe_london
 }
-
-data "aws_security_group" "lambda_security" {
-  name = "Lambda"
-
-  provider = aws.europe_london
-} 
-
 
 data "aws_lambda_layer_version" "lambda_secretsmanager_layer" {
   layer_name = "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension"


### PR DESCRIPTION
This causes the websockets not to be able to be sent back to the client. According to: https://github.com/aws/aws-sdk-go-v2/issues/1534